### PR TITLE
Improve mobile header and branding

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -40,45 +40,10 @@
         transition: opacity 0.5s ease-out;
       }
       
-      .loading-heart {
-        width: 60px;
-        height: 60px;
-        background: #FF6B9D;
-        border-radius: 50px 50px 0 0;
-        position: relative;
-        transform: rotate(45deg);
-        animation: heartbeat 1.5s ease-in-out infinite;
-      }
-      
-      .loading-heart::before,
-      .loading-heart::after {
-        content: '';
-        width: 60px;
-        height: 60px;
-        background: #FF6B9D;
-        border-radius: 50px 50px 0 0;
-        position: absolute;
-      }
-      
-      .loading-heart::before {
-        left: -30px;
-        transform: rotate(-45deg);
-        transform-origin: 30px 30px;
-      }
-      
-      .loading-heart::after {
-        top: -30px;
-        transform: rotate(45deg);
-        transform-origin: 0 30px;
-      }
-      
-      @keyframes heartbeat {
-        0%, 20%, 50%, 80%, 100% {
-          transform: rotate(45deg) scale(1);
-        }
-        40%, 60% {
-          transform: rotate(45deg) scale(1.1);
-        }
+      .loading-logo {
+        width: 70px;
+        height: 70px;
+        animation: pulse 1.6s ease-in-out infinite;
       }
       
       .floating-shapes {
@@ -170,13 +135,22 @@
           transform: translateY(-100px) rotate(360deg);
         }
       }
+
+      @keyframes pulse {
+        0%, 100% {
+          transform: scale(1);
+        }
+        50% {
+          transform: scale(1.1);
+        }
+      }
     </style>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     
     <div id="loading" class="loading-screen">
-      <div class="loading-heart"></div>
+      <img src="%PUBLIC_URL%/logo.svg" class="loading-logo" alt="loading" />
     </div>
     
     <div class="floating-shapes">

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,9 @@
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0ea5e9" />
+      <stop offset="100%" stop-color="#ec4899" />
+    </linearGradient>
+  </defs>
+  <path d="M32 58C12 40 6 30 6 20a12 12 0 0 1 22-8l4 5 4-5a12 12 0 0 1 22 8c0 10-6 20-26 38z" fill="url(#grad)"/>
+</svg>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -6,6 +6,16 @@
       "src": "favicon.ico",
       "sizes": "64x64 32x32 24x24 16x16",
       "type": "image/x-icon"
+    },
+    {
+      "src": "logo192.png",
+      "type": "image/png",
+      "sizes": "192x192"
+    },
+    {
+      "src": "logo512.png",
+      "type": "image/png",
+      "sizes": "512x512"
     }
   ],
   "start_url": ".",

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { 
+import {
   CalendarIcon,
   UserGroupIcon,
   ChatBubbleLeftRightIcon,
@@ -14,12 +14,14 @@ import {
   ArrowRightIcon,
   VideoCameraIcon,
   PhoneIcon,
-  StarIcon
+  StarIcon,
+  UserIcon
 } from '@heroicons/react/24/outline';
 import { useAuth } from '../contexts/AuthContext';
 import { useBookings } from '../hooks/useBookings';
 import { useTherapists } from '../hooks/useTherapists';
 import LoadingSpinner from './LoadingSpinner';
+import Logo from './Logo';
 import { formatDate, formatTime, getInitials, getAvatarColor } from '../utils/helpers';
 
 const Dashboard = () => {
@@ -30,6 +32,7 @@ const Dashboard = () => {
   
   const [greeting, setGreeting] = useState('');
   const [showQuickActions, setShowQuickActions] = useState(false);
+  const [avatarError, setAvatarError] = useState(false);
 
   useEffect(() => {
     const updateGreeting = () => {
@@ -104,9 +107,7 @@ const Dashboard = () => {
           <div className="flex items-center justify-between h-16">
             {/* Logo */}
             <div className="flex items-center space-x-2">
-              <div className="w-8 h-8 sm:w-10 sm:h-10 bg-gradient-to-br from-primary-500 to-secondary-500 rounded-xl flex items-center justify-center">
-                <HeartIcon className="w-5 h-5 sm:w-6 sm:h-6 text-white" />
-              </div>
+              <Logo className="w-8 h-8 sm:w-10 sm:h-10" />
               <span className="text-lg sm:text-xl font-bold font-display bg-gradient-to-r from-primary-600 to-secondary-600 bg-clip-text text-transparent">
                 ClearHeadSpace
               </span>
@@ -145,14 +146,22 @@ const Dashboard = () => {
               {/* Profile - Responsive */}
               <div className="flex items-center space-x-2 sm:space-x-3">
                 <div className={`w-8 h-8 sm:w-10 sm:h-10 rounded-full flex items-center justify-center text-white font-semibold text-xs sm:text-sm ${getAvatarColor(userProfile?.displayName || currentUser?.displayName || 'User')}`}>
-                  {userProfile?.photoURL || currentUser?.photoURL ? (
+                  {userProfile?.photoURL && !avatarError ? (
                     <img
-                      src={userProfile?.photoURL || currentUser?.photoURL}
+                      src={userProfile?.photoURL}
                       alt="Profile"
+                      onError={() => setAvatarError(true)}
+                      className="w-full h-full rounded-full object-cover"
+                    />
+                  ) : currentUser?.photoURL && !avatarError ? (
+                    <img
+                      src={currentUser?.photoURL}
+                      alt="Profile"
+                      onError={() => setAvatarError(true)}
                       className="w-full h-full rounded-full object-cover"
                     />
                   ) : (
-                    getInitials(userProfile?.displayName || currentUser?.displayName || 'User')
+                    <UserIcon className="w-5 h-5" />
                   )}
                 </div>
                 <div className="hidden sm:block">

--- a/src/components/LandingPage.js
+++ b/src/components/LandingPage.js
@@ -1,19 +1,23 @@
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { motion, useScroll, useTransform } from 'framer-motion';
-import { 
-  HeartIcon, 
-  ShieldCheckIcon, 
-  ClockIcon, 
+import Logo from './Logo';
+import {
+  HeartIcon,
+  ShieldCheckIcon,
+  ClockIcon,
   UserGroupIcon,
   ChatBubbleLeftRightIcon,
   SparklesIcon,
   StarIcon,
-  PhoneIcon
+  PhoneIcon,
+  Bars3Icon,
+  XMarkIcon
 } from '@heroicons/react/24/outline';
 
 const LandingPage = () => {
   const [mounted, setMounted] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
   const { scrollY } = useScroll();
   const y1 = useTransform(scrollY, [0, 300], [0, -50]);
   const y2 = useTransform(scrollY, [0, 300], [0, -100]);
@@ -95,9 +99,7 @@ const LandingPage = () => {
             transition={{ duration: 0.6 }}
             className="flex items-center space-x-2"
           >
-            <div className="w-10 h-10 bg-gradient-to-br from-primary-500 to-secondary-500 rounded-xl flex items-center justify-center">
-              <HeartIcon className="w-6 h-6 text-white" />
-            </div>
+            <Logo className="w-10 h-10" />
             <span className="text-xl font-bold font-display bg-gradient-to-r from-primary-600 to-secondary-600 bg-clip-text text-transparent">
               ClearHeadSpace
             </span>
@@ -107,7 +109,7 @@ const LandingPage = () => {
             initial={{ opacity: 0, x: 20 }}
             animate={{ opacity: 1, x: 0 }}
             transition={{ duration: 0.6, delay: 0.1 }}
-            className="flex items-center space-x-4"
+            className="hidden md:flex items-center space-x-4"
           >
             <Link
               to="/signin"
@@ -122,8 +124,39 @@ const LandingPage = () => {
               Get Started
             </Link>
           </motion.div>
+
+          {/* Mobile menu button */}
+          <button
+            className="md:hidden p-2 text-gray-600"
+            onClick={() => setMenuOpen(!menuOpen)}
+          >
+            {menuOpen ? (
+              <XMarkIcon className="w-6 h-6" />
+            ) : (
+              <Bars3Icon className="w-6 h-6" />
+            )}
+          </button>
         </div>
       </nav>
+
+      {menuOpen && (
+        <div className="md:hidden px-6 pb-4 bg-white/80 backdrop-blur-lg border-b border-white/20 space-y-2">
+          <Link
+            to="/signin"
+            className="block text-gray-700 hover:text-primary-600 transition-colors font-medium"
+            onClick={() => setMenuOpen(false)}
+          >
+            Sign In
+          </Link>
+          <Link
+            to="/signup"
+            className="block btn btn-primary w-full text-center"
+            onClick={() => setMenuOpen(false)}
+          >
+            Get Started
+          </Link>
+        </div>
+      )}
 
       {/* Hero Section */}
       <section className="relative z-10 px-6 py-20 lg:py-32">
@@ -374,9 +407,7 @@ const LandingPage = () => {
       <footer className="relative z-10 px-6 py-12 bg-gray-900 text-white">
         <div className="max-w-7xl mx-auto text-center">
           <div className="flex items-center justify-center space-x-2 mb-6">
-            <div className="w-8 h-8 bg-gradient-to-br from-primary-500 to-secondary-500 rounded-lg flex items-center justify-center">
-              <HeartIcon className="w-5 h-5 text-white" />
-            </div>
+            <Logo className="w-8 h-8" />
             <span className="text-lg font-bold font-display">ClearHeadSpace</span>
           </div>
           <p className="text-gray-400 mb-4">

--- a/src/components/Logo.js
+++ b/src/components/Logo.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Logo = ({ className = 'w-10 h-10' }) => (
+  <img src="/logo.svg" alt="ClearHeadSpace" className={className} />
+);
+
+export default Logo;

--- a/src/components/auth/SignIn.js
+++ b/src/components/auth/SignIn.js
@@ -2,12 +2,12 @@ import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { useForm } from 'react-hook-form';
-import { 
-  EyeIcon, 
-  EyeSlashIcon, 
-  HeartIcon,
-  ArrowLeftIcon 
+import {
+  EyeIcon,
+  EyeSlashIcon,
+  ArrowLeftIcon
 } from '@heroicons/react/24/outline';
+import Logo from '../Logo';
 import { useAuth } from '../../contexts/AuthContext';
 import LoadingSpinner from '../LoadingSpinner';
 import { validateEmail } from '../../utils/helpers';
@@ -97,9 +97,7 @@ const SignIn = () => {
               transition={{ duration: 0.5, delay: 0.2 }}
               className="flex items-center justify-center space-x-2 mb-4"
             >
-              <div className="w-12 h-12 bg-gradient-to-br from-primary-500 to-secondary-500 rounded-xl flex items-center justify-center">
-                <HeartIcon className="w-7 h-7 text-white" />
-              </div>
+              <Logo className="w-12 h-12" />
               <span className="text-2xl font-bold font-display bg-gradient-to-r from-primary-600 to-secondary-600 bg-clip-text text-transparent">
                 ClearHeadSpace
               </span>

--- a/src/components/auth/SignUp.js
+++ b/src/components/auth/SignUp.js
@@ -2,10 +2,9 @@ import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useForm } from 'react-hook-form';
-import { 
-  EyeIcon, 
-  EyeSlashIcon, 
-  HeartIcon,
+import {
+  EyeIcon,
+  EyeSlashIcon,
   ArrowLeftIcon,
   ArrowRightIcon,
   CheckCircleIcon,
@@ -14,6 +13,7 @@ import {
   PhoneIcon,
   CalendarIcon
 } from '@heroicons/react/24/outline';
+import Logo from '../Logo';
 import { useAuth } from '../../contexts/AuthContext';
 import LoadingSpinner from '../LoadingSpinner';
 import { validateEmail, validatePhone, formatPhoneNumber } from '../../utils/helpers';
@@ -192,9 +192,7 @@ const SignUp = () => {
               transition={{ duration: 0.5, delay: 0.3 }}
               className="flex items-center justify-center space-x-2 mb-4"
             >
-              <div className="w-12 h-12 bg-gradient-to-br from-primary-500 to-secondary-500 rounded-xl flex items-center justify-center">
-                <HeartIcon className="w-7 h-7 text-white" />
-              </div>
+              <Logo className="w-12 h-12" />
               <span className="text-2xl font-bold font-display bg-gradient-to-r from-primary-600 to-secondary-600 bg-clip-text text-transparent">
                 ClearHeadSpace
               </span>


### PR DESCRIPTION
## Summary
- add Logo component using new SVG icon
- use logo across landing page, auth views and dashboard
- make landing page header responsive on mobile
- refresh splash screen and manifest icons
- handle avatar fallback in dashboard
- remove binary assets

## Testing
- `npm test --silent` *(fails: No tests found related to files changed since last commit)*

------
https://chatgpt.com/codex/tasks/task_e_6841343095b4832d8626adccf5fd8c8b